### PR TITLE
[BB-807] baton-dropbox[Step 3]: add config to /pkg/config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,21 +7,27 @@ import (
 var (
 	AppKey = field.StringField(
 		"app-key",
+		field.WithDisplayName("App key"),
 		field.WithDescription("The app key used to authenticate with Dropbox"),
 		field.WithRequired(true),
 	)
 	AppSecret = field.StringField(
 		"app-secret",
+		field.WithDisplayName("App secret"),
+		field.WithIsSecret(true),
 		field.WithDescription("The app secret used to authenticate with Dropbox"),
 		field.WithRequired(true),
 	)
 	RefreshTokenField = field.StringField(
 		"refresh-token",
+		field.WithDisplayName("OAuth refresh token"),
+		field.WithIsSecret(true),
 		field.WithDescription("The refresh token used to get an access token for authentication with Dropbox"),
 		field.WithRequired(false),
 	)
 	ConfigureField = field.BoolField(
 		"configure",
+		field.WithDisplayName("Configure"),
 		field.WithDescription("Get the refresh token the first time you run the connector."),
 		field.WithRequired(false),
 	)
@@ -34,6 +40,5 @@ var (
 		RefreshTokenField,
 		ConfigureField,
 	}
-	//go:generate go run ./gen
 	ConfigurationSchema = field.NewConfiguration(ConfigurationFields)
 )


### PR DESCRIPTION
#### Description

follow https://conductorone.atlassian.net/wiki/spaces/ENG/pages/2410315780/Containerizing+Connectors+Guide#Step-3%3A-Move-and-update-the-config.go-file 

I will remove the `config` from `cmd` directory in the next pr.



#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `pkg/config/config.go` with configuration fields (`app-key`, `app-secret`, `refresh-token`, `configure`) and exported `ConfigurationSchema`.
> 
> - **Config**:
>   - Add `pkg/config/config.go` with Dropbox auth fields:
>     - `AppKey` and `AppSecret` (required)
>     - `RefreshTokenField` and `ConfigureField` (optional)
>   - Export `ConfigurationFields` and `ConfigurationSchema` for connector configuration (includes `//go:generate` hook).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4e98ac1a875f3100bdddfe0e5a84fe21467e588. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added external configuration for the Dropbox connector, letting users supply required App Key and App Secret.
  - Added optional fields to provide an OAuth refresh token and to enable an initial configuration toggle.
  - Consolidated these fields into a configuration schema to streamline connector setup and validation across interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->