### PR TITLE
docs: add OAuth redirect URI step to connector setup

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -73,6 +73,13 @@ A user with the **Team Admin** role in Dropbox must perform this task.
   Carefully copy and save the app key and app secret.
   </Step>
   <Step>
+  Under **OAuth 2**, add the following redirect URI and click **Add**:
+
+  ```
+  https://accounts.conductor.one/oauth/callback
+  ```
+  </Step>
+  <Step>
   Give the app the relevant set of permissions:
 
   For syncing (read-only) operations:


### PR DESCRIPTION
## Summary

- Adds a missing step in the Dropbox connector setup guide instructing users to add `https://accounts.conductor.one/oauth/callback` as an OAuth 2 redirect URI in the Dropbox App Console's Settings tab
- This step is required for the OAuth flow to succeed when connecting the Dropbox app to C1

Mirrors change from ConductorOne/docs#351.